### PR TITLE
Add base Geode mod template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build artifacts
+build/
+cmake-build-*/
+*.o
+*.obj
+*.dll
+*.dylib
+*.so
+*.pdb
+*.exp
+*.lib
+*.idb
+*.suo
+*.user
+.DS_Store
+.vscode/
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(PaibotGeodeBase VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+option(GEODE_FETCH_SDK "Automatically download the Geode SDK" ON)
+set(GEODE_SDK_DIR "" CACHE PATH "Path to a local clone of the Geode SDK")
+
+if (NOT GEODE_SDK_DIR)
+    set(GEODE_SDK_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.geode-sdk")
+endif()
+
+if (GEODE_FETCH_SDK AND NOT EXISTS "${GEODE_SDK_DIR}/CMakeLists.txt")
+    include(FetchContent)
+    message(STATUS "Fetching Geode SDK into ${GEODE_SDK_DIR}")
+    FetchContent_Declare(geode
+        GIT_REPOSITORY https://github.com/geode-sdk/geode.git
+        GIT_TAG main
+        SOURCE_DIR "${GEODE_SDK_DIR}"
+    )
+    FetchContent_MakeAvailable(geode)
+else()
+    add_subdirectory(${GEODE_SDK_DIR} geode)
+endif()
+
+if (NOT COMMAND setup_geode_mod)
+    if (EXISTS "${GEODE_SDK_DIR}/cmake/Geode.cmake")
+        include(${GEODE_SDK_DIR}/cmake/Geode.cmake)
+    else()
+        message(FATAL_ERROR "Could not locate Geode.cmake. Please ensure the Geode SDK is available.")
+    endif()
+endif()
+
+add_library(${PROJECT_NAME} SHARED src/main.cpp)
+
+setup_geode_mod(${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Base para mods de Geode
+
+Esta es una plantilla mínima inspirada en [Allium](https://github.com/altalk23/Allium) para comenzar un mod de [Geode](https://github.com/geode-sdk) escrito en C++. Incluye una modificación simple de `MenuLayer` que muestra un texto en el menú principal para comprobar que el hook funciona y un ajuste configurable para activarlo o desactivarlo.
+
+## Estructura del proyecto
+
+```
+.
+├── CMakeLists.txt        # Configuración de CMake con descarga opcional del SDK
+├── mod.json              # Metadatos del mod y configuración
+├── src/
+│   └── main.cpp          # Punto de entrada del mod
+└── .gitignore
+```
+
+## Requisitos
+
+- [CMake](https://cmake.org/) 3.21 o superior
+- Compilador C++ con soporte para C++20
+- El SDK de Geode (`geode-sdk`). El script de CMake lo descargará automáticamente a `.geode-sdk/` si no existe.
+
+Si prefieres usar una copia local del SDK, invoca CMake con `-DGEODE_SDK_DIR=/ruta/a/geode-sdk`.
+
+## Compilación
+
+```bash
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+El binario resultante se ubicará en `build/` con el nombre correspondiente a cada plataforma. Copia el archivo y `mod.json` dentro de la carpeta `mods/` de Geode para probarlo.
+
+## Personalización
+
+- Cambia el identificador (`id`) y los metadatos en `mod.json` para tu proyecto.
+- Añade nuevas clases modificadas en `src/` siguiendo la macro `$modify` de Geode.
+- Usa `Mod::get()->getSettingValue<tipo>("clave")` para leer ajustes definidos en `mod.json`.
+
+## Próximos pasos sugeridos
+
+- Añadir más hooks (por ejemplo, a `PlayLayer` o `LevelEditorLayer`).
+- Incorporar assets personalizados dentro de `resources/` y cargarlos desde el código.
+- Configurar acciones en respuesta a eventos de Geode empleando `geode::NotificationCenter`.

--- a/mod.json
+++ b/mod.json
@@ -1,0 +1,41 @@
+{
+  "geode": "2.0.0",
+  "version": "v0.1.0",
+  "id": "paibot.base",
+  "name": "Base Geode Mod",
+  "description": "Plantilla mínima para comenzar un mod de Geode inspirada en Allium.",
+  "authors": [
+    "Paibot"
+  ],
+  "dependencies": [
+    {
+      "id": "geode.loader",
+      "version": ">=2.0.0"
+    }
+  ],
+  "binary": [
+    {
+      "os": "windows",
+      "arch": "x86",
+      "path": "build/PaibotGeodeBase.dll"
+    },
+    {
+      "os": "mac",
+      "arch": "x86",
+      "path": "build/libPaibotGeodeBase.dylib"
+    },
+    {
+      "os": "linux",
+      "arch": "x86",
+      "path": "build/libPaibotGeodeBase.so"
+    }
+  ],
+  "settings": [
+    {
+      "key": "show-menu-label",
+      "name": "Mostrar mensaje en el menú",
+      "type": "bool",
+      "default": true
+    }
+  ]
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,30 @@
+#include <Geode/Geode.hpp>
+#include <Geode/modify/MenuLayer.hpp>
+
+using namespace geode::prelude;
+
+/**
+ * MenuLayer modification that draws a simple label to prove that
+ * the mod is loaded and hooks work correctly.
+ */
+class $modify(BaseMenuLayer, MenuLayer) {
+public:
+    bool init() {
+        if (!MenuLayer::init()) {
+            return false;
+        }
+
+        if (Mod::get()->getSettingValue<bool>("show-menu-label")) {
+            auto winSize = CCDirector::sharedDirector()->getWinSize();
+
+            auto label = CCLabelBMFont::create("Base Geode Mod", "bigFont.fnt");
+            label->setPosition({winSize.width / 2.f, winSize.height - 40.f});
+            label->setScale(0.6f);
+            this->addChild(label);
+        }
+
+        log::info("BaseMenuLayer initialised; menu label added if enabled.");
+
+        return true;
+    }
+};


### PR DESCRIPTION
## Summary
- add a CMake-based Geode mod template that can fetch the SDK automatically and wires up `setup_geode_mod`
- provide a sample `MenuLayer` modification with a configurable setting and basic assets metadata
- document how to build and customize the template in Spanish, inspired by the Allium project

## Testing
- not run (template only)


------
https://chatgpt.com/codex/tasks/task_e_68ccbe67515083319477b8a6fa1fd4ed