### PR TITLE
Fix MenuItemTogglerExtra callback corruption

### DIFF
--- a/src/ui/MenuItemTogglerExtra.cpp
+++ b/src/ui/MenuItemTogglerExtra.cpp
@@ -25,12 +25,16 @@ bool MenuItemTogglerExtra::init(
     std::function<void(MenuItemTogglerExtra*)> const& callback
 ) {
     // Initialize CCMenuItemToggler with off/on sprites and a valid selector
-    m_callback = callback;
     if (!CCMenuItemToggler::init(normalSprite, selectedSprite, this, menu_selector(MenuItemTogglerExtra::onToggle))) {
         return false;
     }
+    // Store callback after base initialization so that any internal resets performed by
+    // CCMenuItemToggler::init don't clobber the functor storage. In certain builds the base
+    // initializer zeroes or fills parts of the object, which previously left m_callback in a
+    // corrupted state (filled with 0xFF) and caused crashes when toggles were clicked.
+    m_callback = callback ? callback : [](MenuItemTogglerExtra*) {};
     // Do not toggle during init to avoid invoking callbacks before the owner wires references
-    
+
     return true;
 }
 
@@ -48,7 +52,7 @@ bool MenuItemTogglerExtra::isToggled() {
 }
 
 void MenuItemTogglerExtra::setCallback(std::function<void(MenuItemTogglerExtra*)> const& callback) {
-    m_callback = callback;
+    m_callback = callback ? callback : [](MenuItemTogglerExtra*) {};
 }
 
 void MenuItemTogglerExtra::onToggle(cocos2d::CCObject*) {


### PR DESCRIPTION
## Summary
- assign MenuItemTogglerExtra callbacks after the CCMenuItemToggler base has finished initialising so the base class cannot clobber the stored functor
- normalise callback setters to always install a safe no-op handler when none is supplied

## Testing
- cmake -S . -B build -DGEODE_TARGET_PLATFORM=Win64 *(fails: network restriction prevents cloning geode-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68cd587819cc833196ea02321d222456