### PR TITLE
Add Gemini conversational bot with persistent memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ __pycache__/
 *.pyc
 *.pyo
 
+# Bot memory storage
+memory/
+
 # Test outputs
 test_outputs/
 snapshots/

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ The mod provides extensive configuration through Geode's settings system:
 4. Preview the 3×3 tile pattern
 5. Export as sprites or JSON preset
 
+## Conversational Assistant
+
+Paibot ahora incluye un asistente conversacional alimentado por Gemini con memoria por usuario.
+
+- **Estilo Paimon**: cuando la conversación menciona explícitamente a Paibot, las respuestas se transforman con el tono energético de Paimon.
+- **Memoria persistente**: el historial de cada usuario se guarda en `memory/<owner>/<repo>/<branch>/usuario.json`, utilizando las variables de entorno `GITHUB_REPO_OWNER`, `GITHUB_REPO_NAME` y `GITHUB_BRANCH`.
+- **Documentación dinámica**: las preguntas sobre comandos leen la información directamente de los archivos `.md` dentro de `commands/` para dar instrucciones precisas.
+- **Gemini API**: el asistente usa la clave `GEMINI_API_KEY` para conectarse al modelo `gemini-pro` y generar respuestas en español conscientes de que se trata de un bot.
+
 ## Building from Source
 
 ### Requirements

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,14 @@
+"""Paibot conversational package."""
+
+from .memory import MemoryManager, MemoryRecord
+from .persona import PaimonPersona
+from .command_docs import CommandDocumentation
+from .chatbot import PaibotChat
+
+__all__ = [
+    "MemoryManager",
+    "MemoryRecord",
+    "PaimonPersona",
+    "CommandDocumentation",
+    "PaibotChat",
+]

--- a/bot/chatbot.py
+++ b/bot/chatbot.py
@@ -1,0 +1,155 @@
+"""Conversational Paibot powered by Gemini with per-user memory."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Iterable, List
+
+import google.generativeai as genai
+
+from .command_docs import CommandDocument, CommandDocumentation
+from .memory import MemoryManager, MemoryRecord
+from .persona import PaimonPersona
+
+COMMAND_PATTERN = re.compile(r"(?:!|/)?(?:comando|command|cmd)[:\s]+(?P<name>[\w-]+)", re.IGNORECASE)
+
+
+class PaibotChat:
+    """High-level chat interface wrapping Gemini with custom behaviour."""
+
+    def __init__(
+        self,
+        *,
+        memory_manager: MemoryManager | None = None,
+        persona: PaimonPersona | None = None,
+        command_docs: CommandDocumentation | None = None,
+        model_name: str = "gemini-pro",
+        model: genai.GenerativeModel | None = None,
+        history_window: int = 12,
+        mention_aliases: Iterable[str] | None = None,
+    ) -> None:
+        self.memory = memory_manager or MemoryManager()
+        self.persona = persona or PaimonPersona()
+        self.command_docs = command_docs or CommandDocumentation()
+        self._history_window = max(history_window, 1)
+        self._mention_aliases = tuple(alias.lower() for alias in (mention_aliases or ("paibot", "@paibot", "paimon")))
+
+        self._system_instruction = (
+            "Eres Paibot, un asistente del mod Paibot para Geometry Dash. "
+            "Siempre recuerda que eres un bot amistoso y habla en español. "
+            "Usa la memoria proporcionada para mantener el contexto y apóyate en la documentación "
+            ".md cuando el usuario pregunte por comandos específicos."
+        )
+        self._generation_config = genai.types.GenerationConfig(
+            temperature=0.75,
+            top_p=0.9,
+            top_k=40,
+            max_output_tokens=512,
+        )
+
+        if model is not None:
+            self._model = model
+        else:
+            api_key = os.environ.get("GEMINI_API_KEY")
+            if not api_key:
+                raise EnvironmentError(
+                    "La variable de entorno GEMINI_API_KEY es necesaria para ejecutar Paibot con Gemini."
+                )
+            genai.configure(api_key=api_key)
+            self._model = genai.GenerativeModel(
+                model_name,
+                system_instruction=self._system_instruction,
+            )
+
+    def respond(self, user_id: str, message: str) -> str:
+        """Generate a response for the provided user message."""
+        message = message.strip()
+        if not message:
+            return "Paimon no escuchó nada, ¡intenta decir algo de nuevo!"
+
+        history = self.memory.load_history(user_id)
+        mention = self._is_mention(message)
+        command_document = self._resolve_command_query(message)
+
+        if command_document:
+            base_response = self._format_command_response(command_document)
+        else:
+            base_response = self._generate_model_reply(history, message, mention)
+
+        final_response = self.persona.stylize(base_response) if mention else base_response
+
+        updated_history = history + [
+            MemoryRecord(role="user", content=message),
+            MemoryRecord(role="assistant", content=final_response, metadata={"mention": str(mention).lower()}),
+        ]
+        trimmed_history = self._trim_history(updated_history)
+        self.memory.save_history(user_id, trimmed_history)
+
+        return final_response
+
+    def _is_mention(self, message: str) -> bool:
+        normalized = message.lower()
+        return any(alias in normalized for alias in self._mention_aliases)
+
+    def _resolve_command_query(self, message: str) -> CommandDocument | None:
+        match = COMMAND_PATTERN.search(message)
+        if match:
+            candidate = match.group("name")
+            document = self.command_docs.get(candidate)
+            if document:
+                return document
+            return self.command_docs.find_best_match(candidate)
+
+        normalized = message.lower()
+        for name in self.command_docs.available_commands():
+            if name in normalized:
+                return self.command_docs.get(name)
+        return None
+
+    def _format_command_response(self, document: CommandDocument) -> str:
+        summary = document.summary()
+        return (
+            f"El comando `{document.name}` funciona así:\n{summary}\n\n"
+            f"Puedes revisar el archivo `{document.path.as_posix()}` para más ejemplos detallados."
+        )
+
+    def _generate_model_reply(self, history: List[MemoryRecord], message: str, mention: bool) -> str:
+        contents: List[dict[str, object]] = []
+        for record in self._recent_history(history):
+            role = "user" if record.role == "user" else "model"
+            contents.append({"role": role, "parts": [record.content]})
+
+        if mention:
+            contents.append(
+                {
+                    "role": "user",
+                    "parts": [
+                        "El usuario acaba de mencionar a Paibot. Responde con un tono alegre inspirado en Paimon, sin olvidar"
+                        " que eres una bot."
+                    ],
+                }
+            )
+
+        contents.append({"role": "user", "parts": [message]})
+
+        response = self._model.generate_content(
+            contents,
+            generation_config=self._generation_config,
+        )
+        text = getattr(response, "text", "")
+        return text.strip() or "Paimon todavía está pensando en la respuesta."
+
+    def _recent_history(self, history: List[MemoryRecord]) -> List[MemoryRecord]:
+        if len(history) <= self._history_window:
+            return history
+        return history[-self._history_window :]
+
+    def _trim_history(self, history: List[MemoryRecord]) -> List[MemoryRecord]:
+        max_records = self._history_window * 2
+        if len(history) <= max_records:
+            return history
+        return history[-max_records:]
+
+
+__all__ = ["PaibotChat"]

--- a/bot/command_docs.py
+++ b/bot/command_docs.py
@@ -1,0 +1,59 @@
+"""Load and search command documentation markdown files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable
+
+
+@dataclass(slots=True)
+class CommandDocument:
+    name: str
+    content: str
+    path: Path
+
+    def summary(self) -> str:
+        """Return a concise summary (first paragraph) of the document."""
+        sections = [section.strip() for section in self.content.split('\n\n') if section.strip()]
+        return sections[0] if sections else self.content.strip()
+
+
+class CommandDocumentation:
+    """Provides access to command documentation stored as markdown files."""
+
+    def __init__(self, docs_directory: Path | None = None) -> None:
+        self._docs_directory = docs_directory or Path("commands")
+        self._documents: Dict[str, CommandDocument] = {}
+        self._load_documents()
+
+    def _load_documents(self) -> None:
+        if not self._docs_directory.exists():
+            return
+        for md_file in self._docs_directory.glob("*.md"):
+            content = md_file.read_text(encoding="utf-8")
+            key = md_file.stem.lower()
+            self._documents[key] = CommandDocument(name=key, content=content, path=md_file)
+
+    def refresh(self) -> None:
+        """Reload documents from disk."""
+        self._documents.clear()
+        self._load_documents()
+
+    def available_commands(self) -> Iterable[str]:
+        return self._documents.keys()
+
+    def get(self, command_name: str) -> CommandDocument | None:
+        return self._documents.get(command_name.lower())
+
+    def find_best_match(self, query: str) -> CommandDocument | None:
+        normalized = query.lower()
+        if normalized in self._documents:
+            return self._documents[normalized]
+        for name, document in self._documents.items():
+            if name in normalized or normalized in name:
+                return document
+        return None
+
+
+__all__ = ["CommandDocument", "CommandDocumentation"]

--- a/bot/memory.py
+++ b/bot/memory.py
@@ -1,0 +1,106 @@
+"""User memory management for Paibot conversations."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List
+
+ISO_TIMESTAMP = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+@dataclass
+class MemoryRecord:
+    """Represents a single conversational memory record."""
+
+    role: str
+    content: str
+    metadata: dict[str, str] | None = None
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).strftime(ISO_TIMESTAMP)
+    )
+
+    def to_json(self) -> dict[str, object]:
+        """Serialize the record to a JSON-compatible dict."""
+        payload = asdict(self)
+        # Drop None metadata to keep files compact
+        if payload.get("metadata") is None:
+            payload.pop("metadata")
+        return payload
+
+
+class MemoryManager:
+    """Stores conversational history per user scoped by repository metadata."""
+
+    def __init__(self, base_directory: Path | None = None) -> None:
+        repo_owner = os.environ.get("GITHUB_REPO_OWNER", "unknown-owner").strip() or "unknown-owner"
+        repo_name = os.environ.get("GITHUB_REPO_NAME", "unknown-repo").strip() or "unknown-repo"
+        branch = os.environ.get("GITHUB_BRANCH", "unknown-branch").strip() or "unknown-branch"
+
+        if base_directory is None:
+            base_directory = Path("memory") / repo_owner / repo_name / branch
+
+        self._base_directory = base_directory
+        self._base_directory.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def base_directory(self) -> Path:
+        """Return the directory root where memories are stored."""
+        return self._base_directory
+
+    def _sanitize_user_id(self, user_id: str) -> str:
+        sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "_", user_id)
+        return sanitized or "anonymous"
+
+    def _memory_file(self, user_id: str) -> Path:
+        filename = f"{self._sanitize_user_id(user_id)}.json"
+        return self._base_directory / filename
+
+    def load_history(self, user_id: str) -> List[MemoryRecord]:
+        """Load the stored history for a user."""
+        path = self._memory_file(user_id)
+        if not path.exists():
+            return []
+
+        with path.open("r", encoding="utf-8") as fp:
+            payload = json.load(fp)
+
+        history: List[MemoryRecord] = []
+        for item in payload.get("history", []):
+            history.append(
+                MemoryRecord(
+                    role=item.get("role", "assistant"),
+                    content=item.get("content", ""),
+                    metadata=item.get("metadata"),
+                    timestamp=item.get("timestamp", datetime.now(timezone.utc).strftime(ISO_TIMESTAMP)),
+                )
+            )
+        return history
+
+    def save_history(self, user_id: str, history: Iterable[MemoryRecord]) -> None:
+        """Persist the provided history for a user."""
+        records = list(history)
+        payload = {
+            "user_id": user_id,
+            "history": [record.to_json() for record in records],
+            "updated_at": datetime.now(timezone.utc).strftime(ISO_TIMESTAMP),
+        }
+        path = self._memory_file(user_id)
+        with path.open("w", encoding="utf-8") as fp:
+            json.dump(payload, fp, ensure_ascii=False, indent=2)
+
+    def append(self, user_id: str, record: MemoryRecord) -> None:
+        """Append a single record to the user's history."""
+        history = self.load_history(user_id)
+        history.append(record)
+        self.save_history(user_id, history)
+
+    def extend(self, user_id: str, records: Iterable[MemoryRecord]) -> None:
+        """Append multiple records to the user's history."""
+        history = self.load_history(user_id)
+        history.extend(records)
+        self.save_history(user_id, history)

--- a/bot/persona.py
+++ b/bot/persona.py
@@ -1,0 +1,49 @@
+"""Persona helpers that give Paibot a Paimon-inspired voice."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(slots=True)
+class PaimonPersona:
+    """Applies Paimon's energetic speaking style to responses."""
+
+    name: str = "Paimon"
+    referential_third_person: bool = True
+    closing_emotes: tuple[str, ...] = ("☆", "✨", "♪", "☄️")
+
+    def _decorate_sentence(self, sentence: str) -> str:
+        sentence = sentence.strip()
+        if not sentence:
+            return sentence
+
+        if self.referential_third_person and not sentence.lower().startswith(self.name.lower()):
+            if len(sentence) > 1:
+                lowered = sentence[0].lower() + sentence[1:]
+            else:
+                lowered = sentence.lower()
+            sentence = f"{self.name} piensa que {lowered}"
+
+        if sentence[-1] not in "!?":
+            sentence = f"{sentence}!"
+        return sentence
+
+    def stylize(self, text: str, context_tags: Iterable[str] | None = None) -> str:
+        """Return a Paimon-styled response."""
+        text = text.strip()
+        if not text:
+            return "¡Paimon está un poco confundida ahora mismo!"
+
+        sentences = [part.strip() for part in text.replace("\n", " ").split('.')]
+        decorated = [self._decorate_sentence(sentence) for sentence in sentences if sentence]
+        if not decorated:
+            decorated = ["¡Paimon no encuentra palabras para esto!"]
+
+        suffix = " " + self.closing_emotes[len(decorated) % len(self.closing_emotes)]
+        awareness = "" if context_tags and "command" in context_tags else " Paimon recuerda que es una bot guía."  # Awareness of being a bot
+        return " ".join(decorated) + awareness + suffix
+
+
+__all__ = ["PaimonPersona"]

--- a/commands/background.md
+++ b/commands/background.md
@@ -1,0 +1,13 @@
+# Comando background
+
+Genera fondos continuos para niveles mediante el generador de Paibot.
+
+## Uso
+1. Llama `!comando background` o pregunta por el fondo continuo.
+2. Selecciona el modo: imagen, síntesis de texturas, procedural o teselas Wang.
+3. Define el tamaño de baldosa (512, 1024, 2048) y ajusta el seed si necesitas variantes.
+4. Exporta como sprites, mapa normal o preset JSON según tu flujo de trabajo.
+
+## Consejos
+- Usa la vista previa 3×3 para comprobar empalmes antes de exportar.
+- Activa la generación determinista para resultados repetibles en equipo.

--- a/commands/gradient.md
+++ b/commands/gradient.md
@@ -1,0 +1,12 @@
+# Comando gradient
+
+Activa el cubo de pintura con degradado en el editor.
+
+## Uso
+1. Escribe `!comando gradient` o menciona "gradient" en tu mensaje.
+2. Configura los pasos del degradado (8-64) y el tipo (lineal, radial o angular).
+3. Selecciona la región a rellenar; Paibot aplicará HSV blending para suavizar los colores.
+
+## Consejos
+- Mantén presionada `Shift` para alinear el ángulo a 90°.
+- Usa `Alt` para alinear el inicio del degradado a la cuadrícula del editor.

--- a/commands/optimizer.md
+++ b/commands/optimizer.md
@@ -1,0 +1,13 @@
+# Comando optimizer
+
+Lanza el optimizador de estructuras para reducir objetos en masa.
+
+## Uso
+1. Ejecuta `!comando optimizer` para obtener asistencia paso a paso.
+2. Define el porcentaje de reducción objetivo (10%-90%).
+3. Ajusta la tolerancia geométrica y el tamaño de snap para preservar la forma.
+4. Revisa el previo antes de aplicar los cambios definitivos.
+
+## Consejos
+- El optimizador usa validación Delta E para mantener la fidelidad visual.
+- Activa el modo seguro si trabajas en niveles incompatibles con la versión actual.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+google-generativeai>=0.6.0

--- a/scripts/run_paibot.py
+++ b/scripts/run_paibot.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""CLI para conversar con Paibot utilizando memoria persistente."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from bot import PaibotChat
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Inicia una sesión de chat con Paibot")
+    parser.add_argument("usuario", help="Identificador del usuario para la memoria persistente")
+    parser.add_argument(
+        "--modelo",
+        default="gemini-pro",
+        help="Nombre del modelo de Gemini a utilizar (por defecto gemini-pro)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    chat = PaibotChat(model_name=args.modelo)
+
+    print("Iniciando conversación con Paibot. Escribe 'salir' para terminar.")
+    while True:
+        try:
+            mensaje = input("Tú: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\nCerrando sesión. ¡Hasta luego!")
+            break
+
+        if mensaje.lower() in {"salir", "exit", "quit"}:
+            print("Cerrando sesión. ¡Hasta luego!")
+            break
+
+        respuesta = chat.respond(args.usuario, mensaje)
+        print(f"Paibot: {respuesta}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Gemini-powered PaibotChat class with Paimon-style responses and per-user memory scoped by GITHUB_* variables
- implement documentation loading for command responses and create markdown guides for gradient, optimizer, and background commands
- expose a CLI entry point plus requirements to run the assistant and document the new conversational features in the README

## Testing
- python -m compileall bot scripts/run_paibot.py

------
https://chatgpt.com/codex/tasks/task_e_68dee6e0f1f4833190f9caed353ffb8b